### PR TITLE
Fix minDateTime and maxDateTime not affecting the grids on datepicker instantiation.

### DIFF
--- a/src/jquery-ui-timepicker-addon.js
+++ b/src/jquery-ui-timepicker-addon.js
@@ -378,7 +378,7 @@
 		*/
 		_injectTimePicker: function () {
 			var $dp = this.inst.dpDiv,
-				o = this.inst.settings,
+				o = this._defaults,
 				tp_inst = this,
 				litem = '',
 				uitem = '',


### PR DESCRIPTION
We noticed this bug when we updated this library from 1.0.1 to the latest version (1.5.5).  What appears to be happening is in `_limitMinMaxDateTime` the `_defaults.hourMin` etc properties are being updated according to what is set for the related `minDateTime` and `maxDateTime` objects are at, however, the grid being setup via `_injectTimePicker` has the `o` variable using `this.inst.settings` instead of `this._defaults`.  This results in the grid being setup using the `hourMin` and `minuteMin` etc properties on `settings` vs `_defaults` and the grid ends up being out of sync with the slider restriction.

My pull request fixes but I'm not sure why `o` was set to `this.inst.settings` so the bug may actually be that the settings property is not getting updated properly.
